### PR TITLE
Middleware tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ c, _ := neptulon.NewConn()
 c.Connect("ws://127.0.0.1:3000")
 c.SendRequest("echo", map[string]string{"message": "Hello!"}, func(ctx *neptulon.ResCtx) error {
 	var msg interface{}
-	ctx.Result(&msg)
+	err := ctx.Result(&msg)
 	fmt.Println("Server sent:", msg)
-	return nil
+	return err
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,13 @@ Neptulon is a bidirectional RPC framework with middleware support. Communication
 
 Neptulon framework is only about 400 lines of code, which makes it easy to fork, specialize, and maintain for specific purposes, if you need to.
 
-## Example
+## Getting Started
 
-Following is server for echoing all incoming messages.
+Following is a server for echoing all incoming messages as is:
 
 ```go
 s := neptulon.NewServer("127.0.0.1:3000")
-
-s.Middleware(func(ctx *neptulon.ReqCtx) error {
-	ctx.Params(&ctx.Res)
-	return ctx.Next()
-})
-
+s.MiddlewareFunc(middleware.Echo)
 s.ListenAndServe()
 ```
 

--- a/conn.go
+++ b/conn.go
@@ -206,6 +206,7 @@ func (c *Conn) startReceive() {
 				defer recoverAndLog(c, &c.wg)
 				if err := newReqCtx(c, m.ID, m.Method, m.Params, c.middleware).Next(); err != nil {
 					log.Printf("ctx: request handler/middleware returned error: %v", err)
+					// todo: we need to notify the user that an internal error occured here, or let that be handled by 'error' middleware?
 					c.Close()
 				}
 			}()

--- a/conn.go
+++ b/conn.go
@@ -256,6 +256,6 @@ func recoverAndLog(c *Conn, wg *sync.WaitGroup) {
 		const size = 64 << 10
 		buf := make([]byte, size)
 		buf = buf[:runtime.Stack(buf, false)]
-		log.Printf("conn: panic handling response %v: %v\n%s", c.RemoteAddr(), err, buf)
+		log.Printf("conn: panic handling response %v: %v\nstack trace: %s", c.RemoteAddr(), err, buf)
 	}
 }

--- a/conn.go
+++ b/conn.go
@@ -135,6 +135,7 @@ func (c *Conn) Close() error {
 }
 
 // Wait waits for all message/connection handler goroutines to exit.
+// Returns error if wait timeouts.
 func (c *Conn) Wait() {
 	c.wg.Wait()
 }

--- a/conn.go
+++ b/conn.go
@@ -216,7 +216,6 @@ func (c *Conn) startReceive() {
 				defer recoverAndLog(c, &c.wg)
 				if err := newReqCtx(c, m.ID, m.Method, m.Params, c.middleware).Next(); err != nil {
 					log.Printf("ctx: request handler/middleware returned error: %v", err)
-					// todo: we need to notify the user that an internal error occured here, or let that be handled by 'error' middleware?
 					c.Close()
 				}
 			}()

--- a/ctx.go
+++ b/ctx.go
@@ -21,6 +21,7 @@ type ReqCtx struct {
 	params  json.RawMessage // request parameters
 	mw      []func(ctx *ReqCtx) error
 	mwIndex int
+	resSent bool
 }
 
 func newReqCtx(conn *Conn, id, method string, params json.RawMessage, mw []func(ctx *ReqCtx) error) *ReqCtx {
@@ -57,8 +58,14 @@ func (ctx *ReqCtx) Next() error {
 		return ctx.mw[ctx.mwIndex-1](ctx)
 	}
 
+	// protect against multiple sends
+	if ctx.resSent {
+		return nil
+	}
+
 	// send the response, if any
 	if ctx.Res != nil || ctx.Err != nil {
+		ctx.resSent = true
 		return ctx.Conn.sendResponse(ctx.ID, ctx.Res, ctx.Err)
 	}
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,6 @@ package neptulon_test
 import (
 	"fmt"
 	"log"
-	"sync"
 	"time"
 
 	"github.com/neptulon/neptulon"
@@ -28,8 +27,9 @@ func Example() {
 		return ctx.Next()
 	})
 	go s.ListenAndServe()
-	time.Sleep(time.Millisecond * 50) // let server goroutine to warm up
 	defer s.Close()
+
+	time.Sleep(time.Millisecond * 50) // let server goroutine to warm up
 
 	// connect to the server and send a message
 	c, err := neptulon.NewConn()
@@ -41,10 +41,7 @@ func Example() {
 	}
 	defer c.Close()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
 	_, err = c.SendRequest("echo", SampleMsg{Message: "Hello!"}, func(ctx *neptulon.ResCtx) error {
-		wg.Done()
 		var msg SampleMsg
 		if err := ctx.Result(&msg); err != nil {
 			return err
@@ -57,6 +54,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	wg.Wait()
+	time.Sleep(time.Millisecond * 50) // wait to get an answer
+
 	// Output: Server says: Hello!
 }

--- a/middleware/error.go
+++ b/middleware/error.go
@@ -1,0 +1,1 @@
+package middleware

--- a/middleware/error.go
+++ b/middleware/error.go
@@ -25,12 +25,16 @@ func Error(ctx *neptulon.ReqCtx) error {
 		log.Printf("mw: error: panic handling response: %v\nstack trace: %s", err, buf)
 	}
 
-	if errored && ctx.Err == nil {
-		ctx.Err = &neptulon.ResError{
-			Code:    500,
-			Message: "Internal server error.",
+	if errored {
+		if ctx.Err == nil {
+			ctx.Err = &neptulon.ResError{
+				Code:    500,
+				Message: "Internal server error.",
+			}
 		}
+
+		return ctx.Next()
 	}
 
-	return ctx.Next()
+	return nil
 }

--- a/middleware/error.go
+++ b/middleware/error.go
@@ -32,5 +32,5 @@ func Error(ctx *neptulon.ReqCtx) error {
 		}
 	}
 
-	return nil
+	return ctx.Next()
 }

--- a/middleware/error.go
+++ b/middleware/error.go
@@ -1,1 +1,36 @@
 package middleware
+
+import (
+	"log"
+	"runtime"
+
+	"github.com/neptulon/neptulon"
+)
+
+// Error is an error/panic handler middleware.
+// Any error/panic is recovered and logged and the error response is returned to the user (auto-generated if none was set).
+func Error(ctx *neptulon.ReqCtx) error {
+	errored := false
+
+	if err := ctx.Next(); err != nil {
+		errored = true
+		log.Printf("mw: error: error handling response: %v", err)
+	}
+
+	if err := recover(); err != nil {
+		errored = true
+		const size = 64 << 10
+		buf := make([]byte, size)
+		buf = buf[:runtime.Stack(buf, false)]
+		log.Printf("mw: error: panic handling response: %v\nstack trace: %s", err, buf)
+	}
+
+	if errored && ctx.Err == nil {
+		ctx.Err = &neptulon.ResError{
+			Code:    500,
+			Message: "Internal server error.",
+		}
+	}
+
+	return nil
+}

--- a/middleware/jwt/jwt_auth.go
+++ b/middleware/jwt/jwt_auth.go
@@ -23,6 +23,10 @@ func HMAC(password string) func(ctx *neptulon.ReqCtx) error {
 			return ctx.Next()
 		}
 
+		if ctx.Res != nil {
+			return ctx.Next()
+		}
+
 		var t token
 		if err := ctx.Params(&t); err != nil {
 			ctx.Conn.Close()

--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -17,6 +17,8 @@ func Logger(ctx *neptulon.ReqCtx) error {
 	if res == nil {
 		res = ctx.Err
 	}
+
 	log.Printf("mw: logger: %v: %v, in: \"%v\", out: \"%#v\"", ctx.ID, ctx.Method, v, res)
+
 	return err
 }

--- a/server.go
+++ b/server.go
@@ -163,7 +163,7 @@ func (s *Server) Close() error {
 // Wait waits for all message/connection handler goroutines in all connections to exit.
 func (s *Server) Wait() {
 	s.conns.Range(func(c interface{}) {
-		c.(*Conn).Wait()
+		c.(*Conn).Wait(180)
 	})
 }
 

--- a/test/conn_helper.go
+++ b/test/conn_helper.go
@@ -85,9 +85,12 @@ func (ch *ConnHelper) SendRequestSync(method string, params interface{}, resHand
 // Waits till all the goroutines handling messages quit.
 func (ch *ConnHelper) CloseWait() {
 	if err := ch.Conn.Close(); err != nil {
-		ch.testing.Fatal("Failed to close connection:", err)
+		ch.testing.Fatal("failed to close connection:", err)
 	}
-	ch.Conn.Wait()
+
+	if err := ch.Conn.Wait(10); err != nil {
+		ch.testing.Fatal("message handler goroutine(s) didn't quit on time:", err)
+	}
 
 	if os.Getenv("TRAVIS") != "" || os.Getenv("CI") != "" {
 		time.Sleep(time.Millisecond * 50)

--- a/test/conn_helper.go
+++ b/test/conn_helper.go
@@ -64,8 +64,9 @@ func (ch *ConnHelper) SendRequestSync(method string, params interface{}, resHand
 	gotRes := make(chan bool)
 
 	_, err := ch.Conn.SendRequest(method, params, func(ctx *neptulon.ResCtx) error {
-		defer func() { gotRes <- true }()
-		return resHandler(ctx)
+		err := resHandler(ctx)
+		gotRes <- true
+		return err
 	})
 
 	if err != nil {

--- a/test/conn_helper.go
+++ b/test/conn_helper.go
@@ -83,8 +83,10 @@ func (ch *ConnHelper) CloseWait() {
 		ch.testing.Fatal("Failed to close connection:", err)
 	}
 	ch.Conn.Wait()
-	time.Sleep(time.Millisecond * 5)
-	if os.Getenv("TRAVIS") != "" || os.Getenv("CI") == "" {
+
+	if os.Getenv("TRAVIS") != "" || os.Getenv("CI") != "" {
 		time.Sleep(time.Millisecond * 50)
+	} else {
+		time.Sleep(time.Millisecond * 5)
 	}
 }

--- a/test/external_client_test.go
+++ b/test/external_client_test.go
@@ -83,7 +83,7 @@ func TestExternalClient(t *testing.T) {
 
 	// handle 'echo' request and send 'close' request upon echo response
 	mc := "Hello from Neptulon Go client!"
-	ch.SendRequest("echo", echoMsg{Message: mc}, func(ctx *neptulon.ResCtx) error {
+	ch.SendRequestSync("echo", echoMsg{Message: mc}, func(ctx *neptulon.ResCtx) error {
 		var msg echoMsg
 		if err := ctx.Result(&msg); err != nil {
 			t.Fatal(err)
@@ -95,7 +95,7 @@ func TestExternalClient(t *testing.T) {
 
 		// send close request after getting our echo message back
 		mb := "Thanks for echoing! Over and out."
-		ch.SendRequest("close", echoMsg{Message: mb}, func(ctx *neptulon.ResCtx) error {
+		ch.SendRequestSync("close", echoMsg{Message: mb}, func(ctx *neptulon.ResCtx) error {
 			var msg echoMsg
 			if err := ctx.Result(&msg); err != nil {
 				t.Fatal(err)

--- a/test/message_test.go
+++ b/test/message_test.go
@@ -24,7 +24,7 @@ var (
 )
 
 func TestEchoWithoutTestHelpers(t *testing.T) {
-	s := neptulon.NewServer("127.0.0.1:3001")
+	s := neptulon.NewServer("127.0.0.1:3002")
 	go s.ListenAndServe()
 	time.Sleep(time.Millisecond * 30)
 	defer s.Close()
@@ -36,7 +36,7 @@ func TestEchoWithoutTestHelpers(t *testing.T) {
 	})
 
 	origin := "http://127.0.0.1"
-	url := "ws://127.0.0.1:3001"
+	url := "ws://127.0.0.1:3002"
 	ws, err := websocket.Dial(url, "", origin)
 	if err != nil {
 		t.Fatal(err)

--- a/test/message_test.go
+++ b/test/message_test.go
@@ -59,14 +59,14 @@ func TestEchoWithoutTestHelpers(t *testing.T) {
 
 func TestEcho(t *testing.T) {
 	sh := NewServerHelper(t)
-	rout := middleware.NewRouter()
+	route := middleware.NewRouter()
 	sh.Server.MiddlewareFunc(middleware.Logger)
-	sh.Server.Middleware(rout)
-	rout.Request("echo", middleware.Echo)
+	sh.Server.Middleware(route)
+	route.Request("echo", middleware.Echo)
 	defer sh.ListenAndServe().CloseWait()
 
-	ch := sh.GetConnHelper()
-	defer ch.Connect().CloseWait()
+	ch := sh.GetConnHelper().Connect()
+	defer ch.CloseWait()
 
 	m := "Hello!"
 	ch.SendRequest("echo", echoMsg{Message: m}, func(ctx *neptulon.ResCtx) error {
@@ -106,8 +106,8 @@ func TestError(t *testing.T) {
 	})
 	defer sh.ListenAndServe().CloseWait()
 
-	ch := sh.GetConnHelper()
-	defer ch.Connect().CloseWait()
+	ch := sh.GetConnHelper().Connect()
+	defer ch.CloseWait()
 
 	ch.SendRequest("testerror", nil, func(ctx *neptulon.ResCtx) error {
 		var v map[string]string

--- a/test/message_test.go
+++ b/test/message_test.go
@@ -69,7 +69,7 @@ func TestEcho(t *testing.T) {
 	defer ch.CloseWait()
 
 	m := "Hello!"
-	ch.SendRequest("echo", echoMsg{Message: m}, func(ctx *neptulon.ResCtx) error {
+	ch.SendRequestSync("echo", echoMsg{Message: m}, func(ctx *neptulon.ResCtx) error {
 		var msg echoMsg
 		if err := ctx.Result(&msg); err != nil {
 			t.Fatal(err)
@@ -109,7 +109,7 @@ func TestError(t *testing.T) {
 	ch := sh.GetConnHelper().Connect()
 	defer ch.CloseWait()
 
-	ch.SendRequest("testerror", nil, func(ctx *neptulon.ResCtx) error {
+	ch.SendRequestSync("testerror", nil, func(ctx *neptulon.ResCtx) error {
 		var v map[string]string
 		if ctx.Success {
 			t.Error("expected to get error response")

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -1,0 +1,1 @@
+package test

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -1,1 +1,11 @@
 package test
+
+import "testing"
+
+func TestMiddlewarePanic(t *testing.T) {
+
+}
+
+func TestMiddlewareErrorReturn(t *testing.T) {
+
+}

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/neptulon/neptulon/middleware"
 )
 
-func TestMiddlewarePanic(t *testing.T) {
+func TestMiddlewarePanics(t *testing.T) {
 	sh := NewServerHelper(t)
 	sh.Server.MiddlewareFunc(middleware.Logger)
 	sh.Server.MiddlewareFunc(func(ctx *neptulon.ReqCtx) error {
@@ -38,7 +38,7 @@ func TestMiddlewarePanic(t *testing.T) {
 	// todo: verify that the server is still up and functional
 }
 
-func TestMiddlewareErrorReturn(t *testing.T) {
+func TestMiddlewareRetursError(t *testing.T) {
 	sh := NewServerHelper(t)
 	sh.Server.MiddlewareFunc(middleware.Logger)
 	sh.Server.MiddlewareFunc(func(ctx *neptulon.ReqCtx) error {
@@ -52,16 +52,13 @@ func TestMiddlewareErrorReturn(t *testing.T) {
 
 	gotRes := make(chan bool)
 	ch.Conn.SendRequest("echo", echoMsg{Message: "just testing"}, func(ctx *neptulon.ResCtx) error {
-		if ctx.ErrorMessage == "" || ctx.ErrorCode == 0 {
-			t.Fatal("expected error response with message, got none")
-		}
 		gotRes <- true
 		return nil
 	})
 
 	select {
 	case <-gotRes:
-	case <-time.After(time.Millisecond * 100):
-		log.Fatal("expected error response, got none")
+		log.Fatal("expected no response, got one")
+	case <-time.After(time.Millisecond * 25):
 	}
 }

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -62,3 +62,21 @@ func TestMiddlewareRetursError(t *testing.T) {
 	case <-time.After(time.Millisecond * 25):
 	}
 }
+
+func TestErrorHandlerMiddleware(t *testing.T) {
+	sh := NewServerHelper(t)
+	sh.Server.MiddlewareFunc(middleware.Logger)
+	sh.Server.MiddlewareFunc(middleware.Error)
+	sh.Server.MiddlewareFunc(func(ctx *neptulon.ReqCtx) error {
+		return errors.New("much error")
+	})
+	sh.Server.MiddlewareFunc(middleware.Echo)
+	defer sh.ListenAndServe().CloseWait()
+
+	ch := sh.GetConnHelper().Connect()
+	defer ch.CloseWait()
+
+	ch.SendRequestSync("echo", echoMsg{Message: "just testing"}, func(ctx *neptulon.ResCtx) error {
+		return nil
+	})
+}

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -30,10 +30,10 @@ func TestMiddlewarePanics(t *testing.T) {
 	select {
 	case <-gotRes:
 		log.Fatal("expected no response, got one")
-	case <-time.After(time.Millisecond * 25):
+	case <-time.After(time.Millisecond * 50):
 	}
 
-	// todo: rather than waiting 25 millisecs, add a Conn.Disconnected handler and check that it is called
+	// todo: rather than waiting 50 millisecs, add a Conn.Disconnected handler and check that it is called
 	// todo: verify that the server is still up and functional
 }
 
@@ -57,7 +57,7 @@ func TestMiddlewareRetursError(t *testing.T) {
 	select {
 	case <-gotRes:
 		log.Fatal("expected no response, got one")
-	case <-time.After(time.Millisecond * 25):
+	case <-time.After(time.Millisecond * 50):
 	}
 }
 

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"errors"
 	"log"
 	"testing"
 	"time"
@@ -33,9 +34,34 @@ func TestMiddlewarePanic(t *testing.T) {
 	case <-time.After(time.Millisecond * 25):
 	}
 
+	// todo: rather than waiting 25 millisecs, add a Conn.Disconnected handler and check that it is called
 	// todo: verify that the server is still up and functional
 }
 
 func TestMiddlewareErrorReturn(t *testing.T) {
+	sh := NewServerHelper(t)
+	sh.Server.MiddlewareFunc(middleware.Logger)
+	sh.Server.MiddlewareFunc(func(ctx *neptulon.ReqCtx) error {
+		return errors.New("much error")
+	})
+	sh.Server.MiddlewareFunc(middleware.Echo)
+	defer sh.ListenAndServe().CloseWait()
 
+	ch := sh.GetConnHelper().Connect()
+	defer ch.CloseWait()
+
+	gotRes := make(chan bool)
+	ch.Conn.SendRequest("echo", echoMsg{Message: "just testing"}, func(ctx *neptulon.ResCtx) error {
+		if ctx.ErrorMessage == "" || ctx.ErrorCode == 0 {
+			t.Fatal("expected error response with message, got none")
+		}
+		gotRes <- true
+		return nil
+	})
+
+	select {
+	case <-gotRes:
+	case <-time.After(time.Millisecond * 100):
+		log.Fatal("expected error response, got none")
+	}
 }

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -1,7 +1,9 @@
 package test
 
 import (
+	"log"
 	"testing"
+	"time"
 
 	"github.com/neptulon/neptulon"
 	"github.com/neptulon/neptulon/middleware"
@@ -19,16 +21,19 @@ func TestMiddlewarePanic(t *testing.T) {
 	ch := sh.GetConnHelper().Connect()
 	defer ch.CloseWait()
 
-	// ch.SendRequest("echo", echoMsg{Message: m}, func(ctx *neptulon.ResCtx) error {
-	// 	var msg echoMsg
-	// 	if err := ctx.Result(&msg); err != nil {
-	// 		t.Fatal(err)
-	// 	}
-	// 	if msg.Message != m {
-	// 		t.Fatalf("expected: %v got: %v", m, msg.Message)
-	// 	}
-	// 	return nil
-	// })
+	gotRes := make(chan bool)
+	ch.Conn.SendRequest("echo", echoMsg{Message: "just testing"}, func(ctx *neptulon.ResCtx) error {
+		gotRes <- true
+		return nil
+	})
+
+	select {
+	case <-gotRes:
+		log.Fatal("expected no response, got one")
+	case <-time.After(time.Millisecond * 25):
+	}
+
+	// todo: verify that the server is still up and functional
 }
 
 func TestMiddlewareErrorReturn(t *testing.T) {

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -16,7 +16,6 @@ func TestMiddlewarePanics(t *testing.T) {
 	sh.Server.MiddlewareFunc(func(ctx *neptulon.ReqCtx) error {
 		panic("much panic")
 	})
-	sh.Server.MiddlewareFunc(middleware.Echo)
 	defer sh.ListenAndServe().CloseWait()
 
 	ch := sh.GetConnHelper().Connect()
@@ -44,7 +43,6 @@ func TestMiddlewareRetursError(t *testing.T) {
 	sh.Server.MiddlewareFunc(func(ctx *neptulon.ReqCtx) error {
 		return errors.New("much error")
 	})
-	sh.Server.MiddlewareFunc(middleware.Echo)
 	defer sh.ListenAndServe().CloseWait()
 
 	ch := sh.GetConnHelper().Connect()
@@ -70,7 +68,6 @@ func TestErrorHandlerMiddleware(t *testing.T) {
 	sh.Server.MiddlewareFunc(func(ctx *neptulon.ReqCtx) error {
 		return errors.New("much error")
 	})
-	sh.Server.MiddlewareFunc(middleware.Echo)
 	defer sh.ListenAndServe().CloseWait()
 
 	ch := sh.GetConnHelper().Connect()

--- a/test/middleware_test.go
+++ b/test/middleware_test.go
@@ -1,9 +1,34 @@
 package test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/neptulon/neptulon"
+	"github.com/neptulon/neptulon/middleware"
+)
 
 func TestMiddlewarePanic(t *testing.T) {
+	sh := NewServerHelper(t)
+	sh.Server.MiddlewareFunc(middleware.Logger)
+	sh.Server.MiddlewareFunc(func(ctx *neptulon.ReqCtx) error {
+		panic("much panic")
+	})
+	sh.Server.MiddlewareFunc(middleware.Echo)
+	defer sh.ListenAndServe().CloseWait()
 
+	ch := sh.GetConnHelper().Connect()
+	defer ch.CloseWait()
+
+	// ch.SendRequest("echo", echoMsg{Message: m}, func(ctx *neptulon.ResCtx) error {
+	// 	var msg echoMsg
+	// 	if err := ctx.Result(&msg); err != nil {
+	// 		t.Fatal(err)
+	// 	}
+	// 	if msg.Message != m {
+	// 		t.Fatalf("expected: %v got: %v", m, msg.Message)
+	// 	}
+	// 	return nil
+	// })
 }
 
 func TestMiddlewareErrorReturn(t *testing.T) {

--- a/test/server_helper.go
+++ b/test/server_helper.go
@@ -77,10 +77,13 @@ func (sh *ServerHelper) ListenAndServe() *ServerHelper {
 		}
 	}()
 
-	time.Sleep(time.Millisecond) // give Accept() enough CPU cycles to initiate
-	if os.Getenv("TRAVIS") != "" || os.Getenv("CI") == "" {
-		time.Sleep(time.Millisecond * 15)
+	// give server enough time to initiate
+	if os.Getenv("TRAVIS") != "" || os.Getenv("CI") != "" {
+		time.Sleep(time.Millisecond * 25)
+	} else {
+		time.Sleep(time.Millisecond)
 	}
+
 	return sh
 }
 
@@ -98,8 +101,11 @@ func (sh *ServerHelper) CloseWait() {
 
 	sh.listenerWG.Wait()
 	sh.Server.Wait()
-	time.Sleep(time.Millisecond * 5)
-	if os.Getenv("TRAVIS") != "" || os.Getenv("CI") == "" {
+
+	// give connections enough time to disconnect properly
+	if os.Getenv("TRAVIS") != "" || os.Getenv("CI") != "" {
 		time.Sleep(time.Millisecond * 50)
+	} else {
+		time.Sleep(time.Millisecond * 5)
 	}
 }


### PR DESCRIPTION
Didn't have integration tests related to middleware functions so adding them now. Trying to cover:
* `panic` inside middleware functions.
* `return err` inside middleware and correlation to `res.Error`. This can be handled by an error middleware (just like it's done in logger, register at top, execute last). We can also have a standard mechanism that will return an generic error response. Closing the connection is not appropriate though as it might break other requests.
* Also, what shall we do if we want to skip a certain middleware (like auth) given that we can't skip `ctx.Next()` as the last middleware is always the sender. We can have something like `ctx.End()` which is old node style (but not Koa).
