### PR TITLE
New style of ctx.Next()-ing

### DIFF
--- a/ctx.go
+++ b/ctx.go
@@ -57,12 +57,7 @@ func (ctx *ReqCtx) Next() error {
 		return ctx.mw[ctx.mwIndex-1](ctx)
 	}
 
-	// send the response, if any
-	if ctx.Res != nil || ctx.Err != nil {
-		return ctx.Conn.sendResponse(ctx.ID, ctx.Res, ctx.Err)
-	}
-
-	return fmt.Errorf("ctx: no response provided for incoming request: %v: %v", ctx.Method, ctx.ID)
+	return nil
 }
 
 // ResCtx is the response context.

--- a/ctx.go
+++ b/ctx.go
@@ -21,7 +21,6 @@ type ReqCtx struct {
 	params  json.RawMessage // request parameters
 	mw      []func(ctx *ReqCtx) error
 	mwIndex int
-	resSent bool
 }
 
 func newReqCtx(conn *Conn, id, method string, params json.RawMessage, mw []func(ctx *ReqCtx) error) *ReqCtx {
@@ -58,14 +57,8 @@ func (ctx *ReqCtx) Next() error {
 		return ctx.mw[ctx.mwIndex-1](ctx)
 	}
 
-	// protect against multiple sends
-	if ctx.resSent {
-		return nil
-	}
-
 	// send the response, if any
 	if ctx.Res != nil || ctx.Err != nil {
-		ctx.resSent = true
 		return ctx.Conn.sendResponse(ctx.ID, ctx.Res, ctx.Err)
 	}
 

--- a/middleware/jwt/jwt_auth.go
+++ b/middleware/jwt/jwt_auth.go
@@ -19,14 +19,12 @@ func HMAC(password string) func(ctx *neptulon.ReqCtx) error {
 	pass := []byte(password)
 
 	return func(ctx *neptulon.ReqCtx) error {
+		// if user is already authenticated
 		if _, ok := ctx.Conn.Session.GetOk("userid"); ok {
 			return ctx.Next()
 		}
 
-		if ctx.Res != nil {
-			return ctx.Next()
-		}
-
+		// if user is not authenticated.. check the JWT token
 		var t token
 		if err := ctx.Params(&t); err != nil {
 			ctx.Conn.Close()


### PR DESCRIPTION
Sending response does not require the final ctx.Next() any more. However sending can still be cancelled via clearing any res/err that is set.